### PR TITLE
Add protocol hierarchy and TCP error support

### DIFF
--- a/config.json
+++ b/config.json
@@ -64,6 +64,8 @@
         "dns_stats": true,
         "http_reqs": true,
         "tls_alerts": true,
-        "slow_resps": true
+        "slow_resps": true,
+        "proto_hier": true,
+        "tcp_errors": true
     }
 }

--- a/config_handler.py
+++ b/config_handler.py
@@ -72,8 +72,14 @@ Your response:
     },
     "llm_params_group_checked": False,
     "wireshark_tasks": {
-        "tcp_conv": True, "ip_conv": False, "dns_stats": True, 
-        "http_reqs": True, "tls_alerts": True, "slow_resps": False
+        "tcp_conv": True,
+        "ip_conv": False,
+        "dns_stats": True,
+        "http_reqs": True,
+        "tls_alerts": True,
+        "slow_resps": False,
+        "proto_hier": False,
+        "tcp_errors": False
     }
 }
 

--- a/main_window.py
+++ b/main_window.py
@@ -300,7 +300,9 @@ class MainWindow(QWidget):
             {"id": "dns_stats", "name": "DNS Statistics", "desc": "Analyze DNS queries and responses for errors."},
             {"id": "http_reqs", "name": "HTTP Requests", "desc": "Extract all HTTP/1.x requests (host, method, URI)."},
             {"id": "tls_alerts", "name": "TLS/SSL Alerts", "desc": "Scan for secure connection failures and warnings."},
-            {"id": "slow_resps", "name": "Slow TCP Responses", "desc": "Find TCP packets with a response time > 200ms."}
+            {"id": "slow_resps", "name": "Slow TCP Responses", "desc": "Find TCP packets with a response time > 200ms."},
+            {"id": "proto_hier", "name": "Protocol Hierarchy", "desc": "Display overall protocol hierarchy statistics."},
+            {"id": "tcp_errors", "name": "TCP Errors", "desc": "List packets flagged with tcp.analysis issues."}
         ]
 
         row, col = 0, 0
@@ -1071,7 +1073,8 @@ class MainWindow(QWidget):
     def _on_dashboard_error_output(self): 
         if not self.dashboard_proc: return
         data = self.dashboard_proc.readAllStandardError().data().decode(sys.stderr.encoding or "utf-8", errors="replace")
-        for line in data.splitlines(): self.append_console(f"DASHBOARD_ERR: {line.rstrip('\r\n')}")
+        for line in data.splitlines():
+            self.append_console(f"DASHBOARD_ERR: {line.rstrip()}")
     
     def _on_dashboard_finished(self, exit_code, exit_status): 
         status = "normally" if exit_status == QProcess.NormalExit else "crashed"; self.append_console(f"Dashboard finished ({status}) code {exit_code}"); self.dashboard_btn.setText("Launch Dashboard")

--- a/monitor.py
+++ b/monitor.py
@@ -133,7 +133,9 @@ def run_tshark_task(pcap_path, tshark_exe_path, task_id):
         "dns_stats":  {"cmd": ["-q", "-z", "dns,tree"], "title": "DNS Statistics"},
         "http_reqs":  {"cmd": ["-Y", "http.request", "-T", "fields", "-e", "http.host", "-e", "http.request.method", "-e", "http.request.uri"], "title": "HTTP Requests"},
         "tls_alerts": {"cmd": ["-Y", "tls.alert_message", "-T", "fields", "-e", "frame.number", "-e", "ip.src", "-e", "ip.dst", "-e", "tls.alert_message.desc"], "title": "TLS/SSL Alerts"},
-        "slow_resps": {"cmd": ["-Y", "tcp.time_delta > 0.2", "-T", "fields", "-e", "frame.number", "-e", "ip.src", "-e", "ip.dst", "-e", "tcp.time_delta"], "title": "Slow TCP Responses (>200ms)"}
+        "slow_resps": {"cmd": ["-Y", "tcp.time_delta > 0.2", "-T", "fields", "-e", "frame.number", "-e", "ip.src", "-e", "ip.dst", "-e", "tcp.time_delta"], "title": "Slow TCP Responses (>200ms)"},
+        "proto_hier": {"cmd": ["-q", "-z", "io,phs"], "title": "Protocol Hierarchy"},
+        "tcp_errors": {"cmd": ["-Y", "tcp.analysis.flags", "-T", "fields", "-e", "frame.number", "-e", "ip.src", "-e", "ip.dst", "-e", "tcp.analysis.flags"], "title": "TCP Errors"}
     }
 
     task = TSHARK_TASKS.get(task_id)


### PR DESCRIPTION
## Summary
- extend available tshark tasks with protocol hierarchy and TCP error checks
- expose the new tasks in Wireshark settings
- persist new task selections in the config file
- fix f-string syntax when showing dashboard errors

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68865bb1d27c8325bfa8324f36671266