### PR TITLE
Add Windows launcher batch file

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,6 @@ The application stores output under the `Resultat` directory.
 
 ## Packaging
 
-`package.py` can be used to create a zip archive of the application while excluding large model files and temporary output.
+`package.py` can be used to create a zip archive of the application while excluding large model files and temporary output. The archive
+includes a `run_dumpbehandler.bat` script for launching the program on Windows. After extracting the zip, double-click the batch file or
+run it from a command prompt to start the GUI.

--- a/run_dumpbehandler.bat
+++ b/run_dumpbehandler.bat
@@ -1,0 +1,4 @@
+@echo off
+REM Launch DumpBehandler using Python
+python "%~dp0main.py" %*
+pause


### PR DESCRIPTION
## Summary
- add a new `run_dumpbehandler.bat` launcher for Windows users
- update README packaging section with instructions

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_688667a879708325b0689127f3826f47