### PR TITLE
Improve documentation for dashboard and guard mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ TechBehandler is a GUI application for analyzing Java diagnostics and network ca
 
 - Launch a PySide6 desktop application for analysis
 - Run a Flask based dashboard to review run results
+- Optional Guard Mode for automatically watching a folder
 - Live capture of network traffic using tshark
 - Manage optional tools via the built in tool manager
 - Configurable prompt templates for LLM based analysis
@@ -34,7 +35,21 @@ or start the dashboard manually:
 python main.py dashboard
 ```
 
+Then browse to [http://localhost:5000/](http://localhost:5000/) to view the web dashboard.
+
 The application stores output under the `Resultat` directory.
+
+### Guard Mode
+
+Guard Mode continuously monitors a chosen folder and automatically processes any
+new `.hprof`, `.pcap`, `.pcapng` or `.txt` files that appear. Enable it from the
+**Dashboard & Guard Mode** tab in the GUI by selecting a folder and setting the
+scan interval. When a stable file is detected it is queued for analysis and the
+results become available in the dashboard.
+
+The HTML templates backing the dashboard UI can be found under the
+[`templates`](templates/) directory, for example
+[index.html](templates/index.html) lists all recorded analysis runs.
 
 ## Packaging
 


### PR DESCRIPTION
## Summary
- document how to start the dashboard and where to open it in the browser
- explain Guard Mode functionality and reference UI templates

## Testing
- `python -m py_compile monitor.py dashboard.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_688667ae36548325bec0ced40433857f