### PR TITLE
Add unit tests and CI workflow

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: pytest -vv

--- a/README.md
+++ b/README.md
@@ -39,3 +39,15 @@ The application stores output under the `Resultat` directory.
 ## Packaging
 
 `package.py` can be used to create a zip archive of the application while excluding large model files and temporary output.
+
+## Testing
+
+Run the unit tests with:
+
+```bash
+pytest
+```
+
+Tests run automatically on GitHub Actions:
+
+[![Tests](https://github.com/<owner>/techbehandler/actions/workflows/python-app.yml/badge.svg)](https://github.com/<owner>/techbehandler/actions/workflows/python-app.yml)

--- a/tests/test_config_handler.py
+++ b/tests/test_config_handler.py
@@ -1,0 +1,63 @@
+import importlib.util
+from pathlib import Path
+import json
+import sys
+import types
+
+
+def load_module(tmp_path):
+    qtcore = types.ModuleType('PySide6.QtCore')
+
+    class QStandardPaths:
+        class StandardLocation:
+            HomeLocation = 0
+
+        @staticmethod
+        def writableLocation(_):
+            return str(tmp_path)
+
+    qtcore.QStandardPaths = QStandardPaths
+    pyside6 = types.ModuleType('PySide6')
+    pyside6.QtCore = qtcore
+    sys.modules['PySide6'] = pyside6
+    sys.modules['PySide6.QtCore'] = qtcore
+    if 'config_handler' in sys.modules:
+        del sys.modules['config_handler']
+    spec = importlib.util.spec_from_file_location(
+        'config_handler', Path(__file__).resolve().parents[1] / 'config_handler.py'
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules['config_handler'] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_load_settings_missing_file(tmp_path, monkeypatch):
+    mod = load_module(tmp_path)
+    cfg_path = tmp_path / 'config.json'
+    monkeypatch.setattr(mod, 'CONFIG_FILE_PATH', cfg_path)
+    settings = mod.load_settings()
+    assert settings == mod.DEFAULT_SETTINGS
+
+
+def test_load_settings_merges_defaults(tmp_path, monkeypatch):
+    mod = load_module(tmp_path)
+    cfg_path = tmp_path / 'config.json'
+    with cfg_path.open('w', encoding='utf-8') as f:
+        json.dump({'guard_mode_enabled': True}, f)
+    monkeypatch.setattr(mod, 'CONFIG_FILE_PATH', cfg_path)
+    settings = mod.load_settings()
+    assert settings['guard_mode_enabled'] is True
+    for key in mod.DEFAULT_SETTINGS:
+        assert key in settings
+
+
+def test_save_settings(tmp_path, monkeypatch):
+    mod = load_module(tmp_path)
+    cfg_path = tmp_path / 'config.json'
+    monkeypatch.setattr(mod, 'CONFIG_FILE_PATH', cfg_path)
+    result = mod.save_settings({'foo': 'bar'})
+    assert result is True
+    with cfg_path.open(encoding='utf-8') as f:
+        data = json.load(f)
+    assert data == {'foo': 'bar'}

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,0 +1,26 @@
+import importlib.util
+from pathlib import Path
+
+# Load the local package.py module explicitly to avoid name clashes
+spec = importlib.util.spec_from_file_location(
+    'package_local', Path(__file__).resolve().parents[1] / 'package.py'
+)
+package = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(package)
+
+
+def test_should_exclude(tmp_path):
+    root_dir = tmp_path
+    file_in_cache = root_dir / '__pycache__' / 'x.pyc'
+    file_in_cache.parent.mkdir()
+    file_in_cache.touch()
+    assert package.should_exclude(str(file_in_cache), str(root_dir)) is True
+
+    log_file = root_dir / 'debug.log'
+    log_file.touch()
+    assert package.should_exclude(str(log_file), str(root_dir)) is True
+
+    normal_file = root_dir / 'data' / 'file.txt'
+    normal_file.parent.mkdir()
+    normal_file.touch()
+    assert package.should_exclude(str(normal_file), str(root_dir)) is False


### PR DESCRIPTION
## Summary
- add pytest workflow
- write tests for `config_handler` and `package` helpers
- document how to run the tests and CI badge in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688667b6dfc083258c102c6311ca8553