### PR TITLE
Enhance resource monitoring with periodic collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - Manage optional tools via the built in tool manager
 - Configurable prompt templates for LLM based analysis
 - System resource monitoring with psutil
+- Repeated metrics collection via `collect_metrics_periodically`
 - Optional security scans using lynis or osquery
 - Nmap network scanning integration
 - Aggregated system log collection

--- a/resource_monitor.py
+++ b/resource_monitor.py
@@ -32,3 +32,33 @@ def collect_once_in_resultat(run_name: str):
     out_path = run_dir / "system_metrics.jsonl"
     return collect_metrics(str(out_path))
 
+
+def collect_metrics_periodically(
+    output_file: str | os.PathLike,
+    iterations: int,
+    interval_seconds: float = 1.0,
+) -> list[dict]:
+    """Collect metrics repeatedly for a number of iterations.
+
+    Parameters
+    ----------
+    output_file:
+        File path to append metrics JSON lines to.
+    iterations:
+        How many samples to collect.
+    interval_seconds:
+        Delay between samples. The first sample is collected immediately.
+
+    Returns
+    -------
+    list of dict
+        A list of metrics dictionaries in the order they were collected.
+    """
+
+    results = []
+    for i in range(iterations):
+        results.append(collect_metrics(output_file))
+        if i < iterations - 1:
+            time.sleep(max(0.0, interval_seconds))
+    return results
+

--- a/tests/test_resource_and_remediation.py
+++ b/tests/test_resource_and_remediation.py
@@ -13,6 +13,7 @@ remediation_engine = importlib.util.module_from_spec(spec_re)
 spec_re.loader.exec_module(remediation_engine)
 
 collect_metrics = resource_monitor.collect_metrics
+collect_metrics_periodically = resource_monitor.collect_metrics_periodically
 generate_remediation = remediation_engine.generate_remediation
 
 
@@ -23,6 +24,15 @@ def test_collect_metrics(tmp_path: Path):
     with out_file.open() as f:
         data = json.loads(f.readline())
     assert metrics["cpu_percent"] == data["cpu_percent"]
+
+
+def test_collect_metrics_periodically(tmp_path: Path):
+    out_file = tmp_path / "metrics.jsonl"
+    results = collect_metrics_periodically(out_file, iterations=3, interval_seconds=0)
+    assert len(results) == 3
+    lines = out_file.read_text().strip().splitlines()
+    assert len(lines) == 3
+
 
 
 def test_generate_remediation(tmp_path: Path):


### PR DESCRIPTION
## Summary
- add a `collect_metrics_periodically` helper to gather metrics multiple times
- document the new API in the README
- test periodic collection in `test_resource_and_remediation`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688678681e488325aee73c2c140e11fa