### PR TITLE
Add launcher batch file with venv setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ pip install -r requirements.txt
 
 Some features require additional third party tools (e.g. Wireshark or Eclipse MAT) which can be downloaded through the Tool Manager dialog.
 
+On Windows you can launch the application with `run_dumpbehandler.bat`. The
+script will create a `venv` folder if needed, install dependencies and then run
+`main.py`.
+
 ## Usage
 
 Run the GUI directly:

--- a/run_dumpbehandler.bat
+++ b/run_dumpbehandler.bat
@@ -1,4 +1,20 @@
 @echo off
+REM Ensure a virtual environment exists and is activated
+set "SCRIPT_DIR=%~dp0"
+set "VENV_DIR=%SCRIPT_DIR%venv"
+
+if "%VIRTUAL_ENV%"=="" (
+    if not exist "%VENV_DIR%" (
+        echo Creating virtual environment...
+        python -m venv "%VENV_DIR%"
+    )
+    echo Activating virtual environment...
+    call "%VENV_DIR%\Scripts\activate"
+)
+
+echo Installing required packages...
+pip install -r "%SCRIPT_DIR%requirements.txt"
+
 REM Launch DumpBehandler using Python
-python "%~dp0main.py" %*
+python "%SCRIPT_DIR%main.py" %*
 pause

--- a/tests/test_helper_scripts.py
+++ b/tests/test_helper_scripts.py
@@ -33,3 +33,10 @@ def test_security_scans(tmp_path: Path):
 def test_log_aggregation(tmp_path: Path):
     log_file = log_aggregator.gather_system_logs(tmp_path)
     assert Path(log_file).exists()
+
+
+def test_batch_launcher_contains_setup():
+    batch_path = ROOT_DIR / "run_dumpbehandler.bat"
+    content = batch_path.read_text()
+    assert "venv" in content
+    assert "pip install" in content


### PR DESCRIPTION
## Summary
- make `run_dumpbehandler.bat` create/activate a `venv` and install dependencies before launching the app
- document Windows launcher in the README
- test that the batch launcher contains the venv setup logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68867c05e6d08325888479a8bb0a0c06