### PR TITLE
Fix Wireshark path detection

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -394,6 +394,10 @@ class MainWindow(QWidget):
                 if launcher_path.is_file():
                     self.append_console(f"Using Wireshark installation found at: {launcher_path}")
                     return str(launcher_path)
+                nested = next(path.rglob(binary), None)
+                if nested:
+                    self.append_console(f"Using Wireshark installation found at: {nested}")
+                    return str(nested)
 
             # Fall back to the manifest-defined location
             if TOOLS_MANIFEST_PATH.exists():
@@ -406,6 +410,10 @@ class MainWindow(QWidget):
                         if launcher_path.is_file():
                             self.append_console(f"Using managed Wireshark (tshark) found at: {launcher_path}")
                             return str(launcher_path)
+                        nested = next(install_path.rglob(binary), None)
+                        if nested:
+                            self.append_console(f"Using managed Wireshark (tshark) found at: {nested}")
+                            return str(nested)
 
             # Last resort: system PATH
             tshark_path = shutil.which("tshark")

--- a/tools.json
+++ b/tools.json
@@ -34,7 +34,7 @@
       "platform": "win64",
       "url": "https://www.wireshark.org/download/win64/WiresharkPortable64_4.2.5.exe",
       "install_path": "tools/wireshark-4.2.5-win64",
-      "launcher_relative_path": "tshark.exe"
+      "launcher_relative_path": "Wireshark/tshark.exe"
     },
     {
       "id": "wireshark",


### PR DESCRIPTION
## Summary
- fix detection of tshark.exe inside Wireshark installation
- look recursively for the executable when searching tools
- update tools.json to match extracted Windows layout

## Testing
- `pip install -r requirements.txt`
- `pip install psutil`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886868c98348325958ea8d05401ea91