### PR TITLE
Handle current directory output in metrics collection

### DIFF
--- a/resource_monitor.py
+++ b/resource_monitor.py
@@ -10,7 +10,22 @@ RESULTAT_DIR = PROJECT_ROOT / "Resultat"
 
 
 def collect_metrics(output_file: str | os.PathLike):
-    """Collect basic system metrics and append as a JSON line."""
+    """Collect basic system metrics and append as a JSON line.
+
+    Parameters
+    ----------
+    output_file:
+        Destination file for the metrics. If the path points to the current
+        working directory (i.e. has no parent folder), the directory creation
+        step is skipped.
+    """
+
+    output_path = Path(output_file)
+    # ``Path.output_path.parent`` resolves to ``'.'`` when no directory
+    # component is provided. ``mkdir`` on ``'.'`` is a no-op, which allows
+    # callers to write metrics directly to the current working directory.
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
     metrics = {
         "timestamp": time.time(),
         "cpu_percent": psutil.cpu_percent(interval=1),
@@ -19,8 +34,8 @@ def collect_metrics(output_file: str | os.PathLike):
         "net_bytes_sent": psutil.net_io_counters().bytes_sent,
         "net_bytes_recv": psutil.net_io_counters().bytes_recv,
     }
-    os.makedirs(os.path.dirname(output_file), exist_ok=True)
-    with open(output_file, "a", encoding="utf-8") as f:
+
+    with output_path.open("a", encoding="utf-8") as f:
         f.write(json.dumps(metrics) + "\n")
     return metrics
 
@@ -30,7 +45,7 @@ def collect_once_in_resultat(run_name: str):
     run_dir = RESULTAT_DIR / run_name
     os.makedirs(run_dir, exist_ok=True)
     out_path = run_dir / "system_metrics.jsonl"
-    return collect_metrics(str(out_path))
+    return collect_metrics(out_path)
 
 
 def collect_metrics_periodically(

--- a/tests/test_resource_and_remediation.py
+++ b/tests/test_resource_and_remediation.py
@@ -26,6 +26,16 @@ def test_collect_metrics(tmp_path: Path):
     assert metrics["cpu_percent"] == data["cpu_percent"]
 
 
+def test_collect_metrics_current_directory(tmp_path: Path, monkeypatch):
+    """Collect metrics when output path is in the current working directory."""
+    monkeypatch.chdir(tmp_path)
+    out_file = Path("metrics.jsonl")
+    metrics = collect_metrics(out_file)
+    assert out_file.exists()
+    data = json.loads(out_file.read_text().splitlines()[0])
+    assert metrics["cpu_percent"] == data["cpu_percent"]
+
+
 def test_collect_metrics_periodically(tmp_path: Path):
     out_file = tmp_path / "metrics.jsonl"
     results = collect_metrics_periodically(out_file, iterations=3, interval_seconds=0)


### PR DESCRIPTION
## Summary
- avoid errors when saving metrics to a file in the current directory by using `Path` APIs to create parent folder only when needed
- add regression test covering metrics collection in current working directory

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689516e7fec883258dd36b40122c70e6