### PR TITLE
Allow selecting system Ghidra installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - Optional Guard Mode for automatically watching a folder
 - Live capture of network traffic using tshark
 - Manage optional tools via the built in tool manager
+- Binary analysis with Ghidra, using a bundled download or a user-selected system installation
 - Configurable prompt templates for LLM based analysis
 - System resource monitoring with psutil
 - Repeated metrics collection via `collect_metrics_periodically`

--- a/main_window.py
+++ b/main_window.py
@@ -464,6 +464,26 @@ class MainWindow(QWidget):
                     if nested:
                         self.append_console(f"Using managed Ghidra found at: {nested}")
                         return str(nested)
+
+            # Fallback: check for a global installation in the system PATH
+            global_launcher = shutil.which("analyzeHeadless")
+            if not global_launcher and sys.platform == "win32":
+                global_launcher = shutil.which("analyzeHeadless.bat")
+            if global_launcher:
+                self.append_console(f"Using system Ghidra found at: {global_launcher}")
+                return global_launcher
+
+            # As a last resort, allow the user to manually select the script
+            file_path, _ = QFileDialog.getOpenFileName(
+                self,
+                "Locate Ghidra analyzeHeadless",
+                str(Path.home()),
+                "analyzeHeadless*"
+            )
+            if file_path:
+                self.append_console(f"Using user-selected Ghidra found at: {file_path}")
+                return file_path
+
         return None
 
     def on_llm_params_group_toggled(self, checked):


### PR DESCRIPTION
## Summary
- add fallback search for system `analyzeHeadless` and user prompt to manually locate Ghidra when managed download is absent
- document that Ghidra can be run via bundled or user-provided installation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68961c6053088325a0893e38125adf02