### PR TITLE
Expose MAT table of contents in dashboard run view

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -258,6 +258,7 @@ def view_run(run):
 
     mat_idx_link_txt = "MAT Report (Not Found)"
     mat_toc_link_txt = "MAT TOC (Not Found)"
+    mat_toc_entries = []
     
     if mat_report_entry_file:
         mat_report_full_path = os.path.join(run_dir_path, mat_report_entry_file)
@@ -266,6 +267,24 @@ def view_run(run):
         mat_toc_path = os.path.join(os.path.dirname(mat_report_full_path), "toc.html")
         if os.path.isfile(mat_toc_path):
             mat_toc_link_txt = "MAT Table of Contents"
+            try:
+                with open(mat_toc_path, "r", encoding="utf-8", errors="ignore") as f_toc:
+                    toc_soup = BeautifulSoup(f_toc.read(), "lxml")
+                for a in toc_soup.find_all("a", href=True):
+                    href = a["href"]
+                    text = a.get_text(strip=True) or href
+                    if href.startswith(("#", "javascript:")):
+                        continue
+                    asset_path_from_toc = Path(os.path.dirname(mat_report_entry_file)) / href
+                    clean_fn = os.path.normpath(asset_path_from_toc).replace("\\", "/")
+                    if clean_fn.startswith("../"):
+                        continue
+                    mat_toc_entries.append({
+                        "text": text,
+                        "url": url_for("get_file_from_run", run=run, filename=clean_fn)
+                    })
+            except Exception as e:
+                log_dashboard_error(f"Err parsing MAT TOC for {run}: {e}")
 
         try:
             with open(mat_report_full_path, "r", encoding="utf-8", errors="ignore") as f_mat_idx:
@@ -340,9 +359,10 @@ def view_run(run):
         mat_overview_pie_chart_url=mat_pie_src, 
         mat_report_index_link_text=mat_idx_link_txt,
         mat_report_toc_link_text=mat_toc_link_txt,
-        mat_report_entry_file=mat_report_entry_file, 
+        mat_report_entry_file=mat_report_entry_file,
+        mat_toc_entries=mat_toc_entries,
         other_run_files=other_files,
-        mat_report_type_used=run_info.get("mat_report_type"), 
+        mat_report_type_used=run_info.get("mat_report_type"),
         user_status=run_info.get("user_status"),
         llm_tags=run_info.get("llm_generated_tags", []),
         llm_params_json=run_info.get("llm_params_json", "{}"),

--- a/templates/view_run.html
+++ b/templates/view_run.html
@@ -207,6 +207,23 @@
                         </div>
                     </div>
 
+                    {% if mat_toc_entries %}
+                    <div class="accordion-item">
+                        <h2 class="accordion-header">
+                            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseMatToc" aria-expanded="false" aria-controls="collapseMatToc">
+                                <i class="bi bi-list-ul me-2"></i>MAT Table of Contents
+                            </button>
+                        </h2>
+                        <div id="collapseMatToc" class="accordion-collapse collapse" data-bs-parent="#detailsAccordion">
+                            <div class="list-group list-group-flush">
+                                {% for entry in mat_toc_entries %}
+                                <a href="{{ entry.url }}" target="_blank" class="list-group-item list-group-item-action">{{ entry.text }}</a>
+                                {% endfor %}
+                            </div>
+                        </div>
+                    </div>
+                    {% endif %}
+
                     <!-- Files Accordion Item -->
                     <div class="accordion-item">
                         <h2 class="accordion-header">


### PR DESCRIPTION
## Summary
- Parse MAT table of contents and gather linked files when viewing a run
- Display MAT table of contents entries in run details accordion

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689655a8e3fc8325ba83c3482ad32d2d