### PR TITLE
Suppress crash errors for deliberate dashboard/webboard stops

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -84,6 +84,9 @@ class MainWindow(QWidget):
         self.dashboard_proc = None
         self.webboard_proc = None
         self.pull_model_proc = None
+
+        self.dashboard_stopping = False
+        self.webboard_stopping = False
         
         self.ollama_available = False
         self.health_check_timer = None 
@@ -1394,11 +1397,10 @@ class MainWindow(QWidget):
     def on_toggle_dashboard(self):
         port = self.port_spin.value()
         if self.dashboard_proc and self.dashboard_proc.state() != QProcess.NotRunning:
-            self.append_console("Stopping dashboard..."); self.dashboard_proc.terminate()
+            self.append_console("Stopping dashboard..."); self.dashboard_stopping = True; self.dashboard_proc.terminate()
             if not self.dashboard_proc.waitForFinished(5000): self.dashboard_proc.kill(); self.dashboard_proc.waitForFinished(3000)
-            self.dashboard_btn.setText("Launch Dashboard"); self.append_console("Dashboard stopped."); self.dashboard_proc = None
         else:
-            self.append_console(f"Starting dashboard on port {port}…"); self.dashboard_proc = QProcess(self)
+            self.append_console(f"Starting dashboard on port {port}…"); self.dashboard_proc = QProcess(self); self.dashboard_stopping = False
             self.dashboard_proc.setProgram(sys.executable)
             args_dashboard = [str(PROJECT_ROOT / "dashboard.py"), f"--port={port}"]
             self.dashboard_proc.setArguments(args_dashboard); self.dashboard_proc.setWorkingDirectory(str(PROJECT_ROOT))
@@ -1411,12 +1413,11 @@ class MainWindow(QWidget):
     def on_toggle_webboard(self):
         port = self.port_spin.value()
         if self.webboard_proc and self.webboard_proc.state() != QProcess.NotRunning:
-            self.append_console("Stopping webboard..."); self.webboard_proc.terminate()
+            self.append_console("Stopping webboard..."); self.webboard_stopping = True; self.webboard_proc.terminate()
             if not self.webboard_proc.waitForFinished(5000): self.webboard_proc.kill(); self.webboard_proc.waitForFinished(3000)
-            self.webboard_btn.setText("Launch Webboard"); self.append_console("Webboard stopped."); self.webboard_proc = None
         else:
             token = secrets.token_urlsafe(16)
-            self.append_console(f"Starting webboard on port {port}…"); self.webboard_proc = QProcess(self)
+            self.append_console(f"Starting webboard on port {port}…"); self.webboard_proc = QProcess(self); self.webboard_stopping = False
             self.webboard_proc.setProgram(sys.executable)
             args_webboard = [str(PROJECT_ROOT / "dashboard.py"), f"--port={port}", "--host=0.0.0.0", f"--token={token}"]
             self.webboard_proc.setArguments(args_webboard); self.webboard_proc.setWorkingDirectory(str(PROJECT_ROOT))
@@ -1441,12 +1442,19 @@ class MainWindow(QWidget):
         for line in data.splitlines():
             self.append_console("DASHBOARD_ERR: " + line.rstrip("\r\n"))
     
-    def _on_dashboard_finished(self, exit_code, exit_status): 
-        status = "normally" if exit_status == QProcess.NormalExit else "crashed"; self.append_console(f"Dashboard finished ({status}) code {exit_code}"); self.dashboard_btn.setText("Launch Dashboard")
-    
+    def _on_dashboard_finished(self, exit_code, exit_status):
+        if self.dashboard_stopping:
+            self.append_console("Dashboard stopped.")
+        else:
+            status = "normally" if exit_status == QProcess.NormalExit else "crashed"
+            self.append_console(f"Dashboard finished ({status}) code {exit_code}")
+        self.dashboard_btn.setText("Launch Dashboard"); self.dashboard_proc = None; self.dashboard_stopping = False
+
     def _on_dashboard_error(self, error):
+        if self.dashboard_stopping and error == QProcess.ProcessError.Crashed:
+            return
         proc_error_string = self.dashboard_proc.errorString() if self.dashboard_proc else "N/A"
-        self.append_console(f"ERROR dashboard process: {error} ({proc_error_string}"); self.dashboard_btn.setText("Launch Dashboard")
+        self.append_console(f"ERROR dashboard process: {error} ({proc_error_string})"); self.dashboard_btn.setText("Launch Dashboard"); self.dashboard_proc = None; self.dashboard_stopping = False
 
     def _on_webboard_output(self):
         if not self.webboard_proc: return
@@ -1460,11 +1468,18 @@ class MainWindow(QWidget):
             self.append_console("WEBBOARD_ERR: " + line.rstrip("\r\n"))
 
     def _on_webboard_finished(self, exit_code, exit_status):
-        status = "normally" if exit_status == QProcess.NormalExit else "crashed"; self.append_console(f"Webboard finished ({status}) code {exit_code}"); self.webboard_btn.setText("Launch Webboard")
+        if self.webboard_stopping:
+            self.append_console("Webboard stopped.")
+        else:
+            status = "normally" if exit_status == QProcess.NormalExit else "crashed"
+            self.append_console(f"Webboard finished ({status}) code {exit_code}")
+        self.webboard_btn.setText("Launch Webboard"); self.webboard_proc = None; self.webboard_stopping = False
 
     def _on_webboard_error(self, error):
+        if self.webboard_stopping and error == QProcess.ProcessError.Crashed:
+            return
         proc_error_string = self.webboard_proc.errorString() if self.webboard_proc else "N/A"
-        self.append_console(f"ERROR webboard process: {error} ({proc_error_string})"); self.webboard_btn.setText("Launch Webboard")
+        self.append_console(f"ERROR webboard process: {error} ({proc_error_string})"); self.webboard_btn.setText("Launch Webboard"); self.webboard_proc = None; self.webboard_stopping = False
 
     def _get_local_ip(self):
         try:


### PR DESCRIPTION
## Summary
- Track when dashboard and webboard processes are intentionally terminated
- Avoid reporting QProcess.Crashed errors when termination is expected
- Log neutral "stopped" messages for expected shutdowns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68965e3f36748325a233c9e6a7542bb1