### PR TITLE
Improve run page layout and inline file viewing

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -419,14 +419,11 @@ def view_run(run):
             log_dashboard_error(f"Err listing MAT index files for {run}: {e}")
 
     other_files = []
+    viewable_files = []
     try:
         md_name_only = os.path.basename(run_info["md_filename_processed"]) if run_info.get("md_filename_processed") else ""
 
         excluded_files = {"run_metadata.json", md_name_only}
-        if mat_report_entry_file:
-            excluded_files.add(mat_report_entry_file)
-            toc_candidate = os.path.join(os.path.dirname(mat_report_entry_file), "toc.html").replace("\\", "/")
-            excluded_files.add(toc_candidate)
 
         for root_dir, _, files in os.walk(run_dir_path):
             for f in files:
@@ -436,6 +433,11 @@ def view_run(run):
                 other_files.append(rel_path)
 
         other_files = sorted(other_files)
+
+        viewable_exts = {".txt", ".log", ".html", ".htm", ".json", ".md", ".csv"}
+        for f in other_files:
+            if os.path.splitext(f.lower())[1] in viewable_exts:
+                viewable_files.append(f)
 
     except Exception as e:
         log_dashboard_error(f"Err listing files for {run}: {e}")
@@ -471,6 +473,7 @@ def view_run(run):
 
         mat_index_files=mat_extra_index_entries,
         other_run_files=other_files,
+        viewable_run_files=viewable_files,
         mat_report_type_used=run_info.get("mat_report_type"),
         user_status=run_info.get("user_status"),
 

--- a/templates/view_run.html
+++ b/templates/view_run.html
@@ -91,184 +91,122 @@
             </div>
         </div>
 
-        <div class="row g-4">
-            <!-- Main Content Column -->
-            <div class="col-lg-8">
-                <!-- LLM Analysis Card -->
-                <div class="card mb-4">
-                    <div class="card-header fs-5 d-flex justify-content-between align-items-center">
-                        <span><i class="bi bi-robot"></i> LLM Analysis</span>
-                        <small class="text-muted" id="model-used-display">Model: {{ model_used }}</small>
-                    </div>
-                    <div class="card-body llm-analysis-body">
-                        <div class="mb-3" id="tags-container">
-                            {% for tag in llm_tags %}
-                                <span class="badge rounded-pill text-bg-primary tag">{{ tag }}</span>
-                            {% else %}
-                                <span class="text-muted">No tags generated.</span>
-                            {% endfor %}
-                        </div>
-                        <hr>
-                        <div id="llm-analysis-content">
-                            {{ llm_analysis_html|safe }}
-                        </div>
-                    </div>
+        <!-- Run Details -->
+        <div class="card mb-4">
+            <div class="card-header fs-5"><i class="bi bi-info-circle"></i> Run Details</div>
+            <div class="card-body">
+                <p class="mb-2"><strong>Input File:</strong><br><small class="text-muted">{{ hprof_source }}</small></p>
+                <p class="mb-2"><strong>Timestamp:</strong><br>{{ run_time }}</p>
+                <p class="mb-2"><strong>MAT Memory:</strong> {{ mat_memory_setting }} MB</p>
+                <p class="mb-2"><strong>MAT Report Type:</strong> {{ mat_report_type_used }}</p>
+                <div class="mt-3">
+                    <label for="notesTextarea" class="form-label">Run Notes</label>
+                    <textarea id="notesTextarea" class="form-control mb-2" rows="4" placeholder="Add notes...">{{ user_notes }}</textarea>
+                    <button id="saveNotesBtn" class="btn btn-sm btn-primary">Save Notes</button>
                 </div>
+            </div>
+        </div>
 
-                <!-- Interactive Chat Card -->
-                <div class="card mb-4">
-                    <div class="card-header fs-5"><i class="bi bi-chat-dots"></i> Interactive Chat</div>
-                    <div class="card-body chat-container p-0">
-                        <div class="chat-box p-3">
-                            <!-- Messages will be appended here -->
-                        </div>
-                        <div class="p-3 border-top bg-light">
-                            <div class="input-group">
-                                <input type="text" id="chatInput" class="form-control" placeholder="Ask a follow-up question..." aria-label="User message">
-                                <button class="btn btn-primary" type="button" id="sendChatBtn"><i class="bi bi-send"></i></button>
-                            </div>
-                        </div>
+        <!-- LLM Analysis -->
+        <div class="card mb-4">
+            <div class="card-header fs-5 d-flex justify-content-between align-items-center">
+                <span><i class="bi bi-robot"></i> LLM Analysis</span>
+                <small class="text-muted" id="model-used-display">Model: {{ model_used }}</small>
+            </div>
+            <div class="card-body llm-analysis-body">
+                <div class="mb-3" id="tags-container">
+                    {% for tag in llm_tags %}
+                        <span class="badge rounded-pill text-bg-primary tag">{{ tag }}</span>
+                    {% else %}
+                        <span class="text-muted">No tags generated.</span>
+                    {% endfor %}
+                </div>
+                <hr>
+                <div id="llm-analysis-content">
+                    {{ llm_analysis_html|safe }}
+                </div>
+            </div>
+        </div>
+
+        <!-- Interactive Chat -->
+        <div class="card mb-4">
+            <div class="card-header fs-5"><i class="bi bi-chat-dots"></i> Interactive Chat</div>
+            <div class="card-body chat-container p-0">
+                <div class="chat-box p-3">
+                    <!-- Messages will be appended here -->
+                </div>
+                <div class="p-3 border-top bg-light">
+                    <div class="input-group">
+                        <input type="text" id="chatInput" class="form-control" placeholder="Ask a follow-up question..." aria-label="User message">
+                        <button class="btn btn-primary" type="button" id="sendChatBtn"><i class="bi bi-send"></i></button>
                     </div>
                 </div>
             </div>
+        </div>
 
-            <!-- Sidebar Column -->
-            <div class="col-lg-4">
-                <div class="accordion" id="detailsAccordion">
-                    <!-- Run Details Accordion Item -->
-                    <div class="accordion-item">
-                        <h2 class="accordion-header">
-                            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseDetails" aria-expanded="true" aria-controls="collapseDetails">
-                                <i class="bi bi-info-circle me-2"></i>Run Details
-                            </button>
-                        </h2>
-                        <div id="collapseDetails" class="accordion-collapse collapse show" data-bs-parent="#detailsAccordion">
-                            <div class="card-body">
-                                <p class="mb-2"><strong>Input File:</strong><br><small class="text-muted">{{ hprof_source }}</small></p>
-                                <p class="mb-2"><strong>Timestamp:</strong><br>{{ run_time }}</p>
-                                <p class="mb-2"><strong>MAT Memory:</strong> {{ mat_memory_setting }} MB</p>
-                                <p class="mb-2"><strong>MAT Report Type:</strong> {{ mat_report_type_used }}</p>
-                            </div>
+        <!-- Diagnostic Data -->
+        <div class="card mb-4">
+            <div class="card-header fs-5"><i class="bi bi-file-earmark-text"></i> Diagnostic Data</div>
+            <div class="card-body" style="max-height: 800px; overflow-y: auto;">
+                <div class="input-group input-group-sm mb-2">
+                    <span class="input-group-text">Search</span>
+                    <input id="rawSearchInput" type="text" class="form-control" placeholder="Find in data...">
+                </div>
+                <h6>LLM Parameters Used</h6>
+                <pre><code>{{ llm_params_json }}</code></pre>
+                <h6 class="mt-3">Diagnostic Data</h6>
+                <pre id="diagnosticPre"><code>{{ oom_trace_details|safe }}</code></pre>
+                {% if 'not available' not in mat_problem_suspect_html %}
+                <hr>
+                <h6 class="mt-3">MAT Problem Suspect Details</h6>
+                {% if mat_overview_pie_chart_url %}
+                <img src="{{ mat_overview_pie_chart_url }}" class="img-fluid rounded mb-3" alt="MAT Pie Chart">
+                {% endif %}
+                {{ mat_problem_suspect_html|safe }}
+                {% endif %}
+            </div>
+        </div>
+
+        <!-- Viewable Other Files -->
+        <div class="card mb-4">
+            <div class="card-header fs-5"><i class="bi bi-folder2-open"></i> View Other Files</div>
+            <div class="card-body">
+                <div class="row">
+                    <div class="col-md-4 mb-3 mb-md-0">
+                        <div class="list-group" id="viewableFilesList">
+                            {% if mat_report_entry_file %}
+                            <a href="#" class="list-group-item list-group-item-action view-file" data-file-url="{{ url_for('get_file_from_run', run=run_name, filename=mat_report_entry_file) }}">{{ mat_report_index_link_text }}</a>
+                            {% if 'not found' not in mat_report_toc_link_text|lower %}
+                            <a href="#" class="list-group-item list-group-item-action view-file" data-file-url="{{ url_for('get_file_from_run', run=run_name, filename=mat_report_entry_file.replace('index.html', 'toc.html')) }}">{{ mat_report_toc_link_text }}</a>
+                            {% endif %}
+                            {% endif %}
+                            {% for entry in mat_toc_entries %}
+                            <a href="#" class="list-group-item list-group-item-action view-file" data-file-url="{{ entry.url }}">{{ entry.text }}</a>
+                            {% endfor %}
+                            {% for entry in mat_index_files %}
+                            <a href="#" class="list-group-item list-group-item-action view-file" data-file-url="{{ entry.url }}">{{ entry.text }}</a>
+                            {% endfor %}
+                            {% for file in viewable_run_files %}
+                            <a href="#" class="list-group-item list-group-item-action view-file" data-file-url="{{ url_for('get_file_from_run', run=run_name, filename=file) }}">{{ file }}</a>
+                            {% endfor %}
                         </div>
                     </div>
-
-                    <!-- Notes Accordion Item -->
-                    <div class="accordion-item">
-                        <h2 class="accordion-header">
-                            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseNotes" aria-expanded="false" aria-controls="collapseNotes">
-                                <i class="bi bi-journal-text me-2"></i>Run Notes
-                            </button>
-                        </h2>
-                        <div id="collapseNotes" class="accordion-collapse collapse" data-bs-parent="#detailsAccordion">
-                            <div class="accordion-body">
-                                <textarea id="notesTextarea" class="form-control mb-2" rows="4" placeholder="Add notes...">{{ user_notes }}</textarea>
-                                <button id="saveNotesBtn" class="btn btn-sm btn-primary">Save Notes</button>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- MAT Suspects Accordion Item -->
-                    {% if 'not available' not in mat_problem_suspect_html %}
-                    <div class="accordion-item">
-                        <h2 class="accordion-header">
-                            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseSuspects" aria-expanded="false" aria-controls="collapseSuspects">
-                                <i class="bi bi-search me-2"></i>MAT Problem Suspect Details
-                            </button>
-                        </h2>
-                        <div id="collapseSuspects" class="accordion-collapse collapse" data-bs-parent="#detailsAccordion">
-                            <div class="accordion-body" style="max-height: 400px; overflow-y: auto;">
-                                {% if mat_overview_pie_chart_url %}
-                                <img src="{{ mat_overview_pie_chart_url }}" class="img-fluid rounded mb-3" alt="MAT Pie Chart">
-                                {% endif %}
-                                {{ mat_problem_suspect_html|safe }}
-                            </div>
-                        </div>
-                    </div>
-                    {% endif %}
-                    
-                    <!-- Raw Data Accordion Item -->
-
-
-                    <div class="accordion-item">
-                        <h2 class="accordion-header">
-                            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseRawData" aria-expanded="false" aria-controls="collapseRawData">
-                                <i class="bi bi-file-earmark-text me-2"></i>Raw Diagnostic Data
-                            </button>
-                        </h2>
-                        <div id="collapseRawData" class="accordion-collapse collapse" data-bs-parent="#detailsAccordion">
-                            <div class="accordion-body" style="max-height: 500px; overflow-y: auto;">
-                                <div class="input-group input-group-sm mb-2">
-                                    <span class="input-group-text">Search</span>
-                                    <input id="rawSearchInput" type="text" class="form-control" placeholder="Find in data...">
-                                </div>
-                                <h6>LLM Parameters Used</h6>
-                                <pre><code>{{ llm_params_json }}</code></pre>
-                                <h6 class="mt-3">Diagnostic Data</h6>
-                                <pre id="diagnosticPre"><code>{{ oom_trace_details|safe }}</code></pre>
-                            </div>
-                        </div>
-                    </div>
-
-                    {% if mat_toc_entries %}
-                    <div class="accordion-item">
-                        <h2 class="accordion-header">
-                            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseMatToc" aria-expanded="false" aria-controls="collapseMatToc">
-                                <i class="bi bi-list-ul me-2"></i>MAT Table of Contents
-                            </button>
-                        </h2>
-                        <div id="collapseMatToc" class="accordion-collapse collapse" data-bs-parent="#detailsAccordion">
-                            <div class="list-group list-group-flush">
-                                {% for entry in mat_toc_entries %}
-                                <a href="{{ entry.url }}" target="_blank" class="list-group-item list-group-item-action">{{ entry.text }}</a>
-                                {% endfor %}
-                            </div>
-                        </div>
-                    </div>
-                    {% endif %}
-
-
-                    {% if mat_index_files %}
-                    <div class="accordion-item">
-                        <h2 class="accordion-header">
-                            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseMatIndexes" aria-expanded="false" aria-controls="collapseMatIndexes">
-                                <i class="bi bi-journal-text me-2"></i>MAT Index Files
-                            </button>
-                        </h2>
-                        <div id="collapseMatIndexes" class="accordion-collapse collapse" data-bs-parent="#detailsAccordion">
-                            <div class="list-group list-group-flush">
-                                {% for entry in mat_index_files %}
-                                <a href="{{ entry.url }}" target="_blank" class="list-group-item list-group-item-action">{{ entry.text }}</a>
-                                {% endfor %}
-                            </div>
-                        </div>
-                    </div>
-                    {% endif %}
-
-
-
-                    <!-- Other Files Accordion Item -->
-                    <div class="accordion-item">
-                        <h2 class="accordion-header">
-                            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseFiles" aria-expanded="false" aria-controls="collapseFiles">
-                                <i class="bi bi-folder2-open me-2"></i>Other Files
-
-                            </button>
-                        </h2>
-                        <div id="collapseFiles" class="accordion-collapse collapse" data-bs-parent="#detailsAccordion">
-                            <div class="list-group list-group-flush">
-                                {% if mat_report_entry_file %}
-                                    <a href="{{ url_for('get_file_from_run', run=run_name, filename=mat_report_entry_file) }}" target="_blank" class="list-group-item list-group-item-action"><i class="bi bi-file-earmark-code me-2"></i>{{ mat_report_index_link_text }}</a>
-                                    {% if 'not found' not in mat_report_toc_link_text|lower %}
-                                    <a href="{{ url_for('get_file_from_run', run=run_name, filename=mat_report_entry_file.replace('index.html', 'toc.html')) }}" target="_blank" class="list-group-item list-group-item-action"><i class="bi bi-list-ul me-2"></i>{{ mat_report_toc_link_text }}</a>
-                                    {% endif %}
-                                {% endif %}
-                                {% for file in other_run_files %}
-                                <a href="{{ url_for('get_file_from_run', run=run_name, filename=file) }}" target="_blank" class="list-group-item list-group-item-action"><i class="bi bi-file-text me-2"></i>{{ file }}</a>
-                                {% endfor %}
-                            </div>
-                        </div>
+                    <div class="col-md-8">
+                        <iframe id="fileViewer" style="width:100%; height:600px; border:1px solid #dee2e6;"></iframe>
                     </div>
                 </div>
+            </div>
+        </div>
+
+        <!-- Download Other Files -->
+        <div class="card mb-4">
+            <div class="card-header fs-5"><i class="bi bi-download"></i> Download Other Files</div>
+            <div class="list-group list-group-flush">
+                {% for file in other_run_files %}
+                <a href="{{ url_for('get_file_from_run', run=run_name, filename=file) }}" class="list-group-item list-group-item-action" download>{{ file }}</a>
+                {% else %}
+                <span class="list-group-item">No additional files.</span>
+                {% endfor %}
             </div>
         </div>
     </div>
@@ -566,6 +504,15 @@
             diagnosticPre.innerHTML = '<code>' + escaped.replace(regex, m => '<mark>' + m + '</mark>') + '</code>';
         }
         rawSearchInput.addEventListener('input', highlightSearch);
+
+        // Viewable file links
+        document.querySelectorAll('.view-file').forEach(link => {
+            link.addEventListener('click', function(e) {
+                e.preventDefault();
+                const url = this.getAttribute('data-file-url');
+                document.getElementById('fileViewer').src = url;
+            });
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Restructure run view into sequential sections for details, analysis, diagnostics, and files
- Categorize run files so viewable types are shown inline with a new file viewer
- Add separate download list for all run files
- Ensure MAT-generated index and toc HTML files appear in both viewable and downloadable file lists

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68965f54f5d48325a84c2c51ddb63e41