### PR TITLE
Reorganize run view with MAT details first and dark mode

### DIFF
--- a/templates/view_run.html
+++ b/templates/view_run.html
@@ -6,11 +6,15 @@
     <title>Run: {{ run_name }} - DumpBehandler</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
-    <style>
+        <style>
         body {
             font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif;
             background-color: #f8f9fa;
             color: #212529;
+        }
+        body.dark-mode {
+            background-color: #121212;
+            color: #f8f9fa;
         }
         .container-fluid {
             max-width: 1800px;
@@ -19,9 +23,17 @@
             border: 1px solid #dee2e6;
             box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
         }
+        .dark-mode .card {
+            background-color: #1e1e1e;
+            border-color: #343a40;
+        }
         .card-header {
             background-color: #f8f9fa;
             font-weight: 500;
+        }
+        .dark-mode .card-header {
+            background-color: #343a40;
+            color: #f8f9fa;
         }
         h1.page-title {
             font-weight: 300;
@@ -48,13 +60,19 @@
             white-space: pre-wrap;
             word-wrap: break-word;
         }
+        .dark-mode pre, .dark-mode code {
+            background-color: #212529;
+            color: #f8f9fa;
+        }
         .chat-container { max-height: 600px; display: flex; flex-direction: column; }
         .chat-box { flex-grow: 1; overflow-y: auto; background-color: #fff; padding: 10px; }
+        .dark-mode .chat-box { background-color: #1e1e1e; color: #f8f9fa; }
         .chat-message { margin-bottom: 0.5rem; line-height: 1.4; }
         .chat-message.user { display: flex; justify-content: flex-end; }
         .chat-message.user .message-bubble { background-color: #0d6efd; color: white; }
         .chat-message.assistant { display: flex; justify-content: flex-start; }
         .chat-message.assistant .message-bubble { background-color: #e9ecef; color: #212529; }
+        .dark-mode .chat-message.assistant .message-bubble { background-color: #343a40; color: #f8f9fa; }
         .message-bubble { padding: 0.5rem 1rem; border-radius: 1rem; max-width: 85%; }
         .message-bubble p:last-child { margin-bottom: 0; }
         .message-bubble pre { font-size: 0.85em; }
@@ -65,6 +83,9 @@
         .accordion-button:focus {
             box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
         }
+        .dark-mode .bg-light { background-color: #343a40 !important; color: #f8f9fa; }
+        .dark-mode .list-group-item { background-color: #1e1e1e; color: #f8f9fa; }
+        .dark-mode .list-group-item-action:hover { background-color: #343a40; color: #f8f9fa; }
     </style>
 </head>
 <body>
@@ -73,6 +94,7 @@
         <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
             <h1 class="h2 page-title"><a href="/" class="text-decoration-none text-dark"><i class="bi bi-arrow-left-circle"></i></a> Run: <span id="run-name-header">{{ run_name }}</span></h1>
             <div class="btn-toolbar mb-2 mb-md-0">
+                <button id="darkModeToggle" type="button" class="btn btn-sm btn-outline-secondary me-2"><i class="bi bi-moon"></i></button>
                 <button type="button" class="btn btn-sm btn-outline-primary me-2" data-bs-toggle="modal" data-bs-target="#reevaluateModal">
                     <i class="bi bi-arrow-clockwise"></i> Re-evaluate with LLM
                 </button>
@@ -91,18 +113,54 @@
             </div>
         </div>
 
-        <!-- Run Details -->
+        {% if 'not available' not in mat_problem_suspect_html %}
+        <!-- MAT Problem Suspect Details -->
         <div class="card mb-4">
-            <div class="card-header fs-5"><i class="bi bi-info-circle"></i> Run Details</div>
+            <div class="card-header fs-5"><i class="bi bi-exclamation-triangle"></i> MAT Problem Suspect Details</div>
             <div class="card-body">
-                <p class="mb-2"><strong>Input File:</strong><br><small class="text-muted">{{ hprof_source }}</small></p>
-                <p class="mb-2"><strong>Timestamp:</strong><br>{{ run_time }}</p>
-                <p class="mb-2"><strong>MAT Memory:</strong> {{ mat_memory_setting }} MB</p>
-                <p class="mb-2"><strong>MAT Report Type:</strong> {{ mat_report_type_used }}</p>
-                <div class="mt-3">
-                    <label for="notesTextarea" class="form-label">Run Notes</label>
-                    <textarea id="notesTextarea" class="form-control mb-2" rows="4" placeholder="Add notes...">{{ user_notes }}</textarea>
-                    <button id="saveNotesBtn" class="btn btn-sm btn-primary">Save Notes</button>
+                {% if mat_overview_pie_chart_url %}
+                <img src="{{ mat_overview_pie_chart_url }}" class="img-fluid rounded mb-3" alt="MAT Pie Chart">
+                {% endif %}
+                {{ mat_problem_suspect_html|safe }}
+            </div>
+        </div>
+{% endif %}
+
+        <!-- Diagnostic Data -->
+        <div class="card mb-4">
+            <div class="card-header fs-5"><i class="bi bi-file-earmark-text"></i> Diagnostic Data</div>
+            <div class="card-body" style="max-height: 800px; overflow-y: auto;">
+                <div class="input-group input-group-sm mb-2">
+                    <span class="input-group-text">Search</span>
+                    <input id="rawSearchInput" type="text" class="form-control" placeholder="Find in data...">
+                </div>
+                <h6>LLM Parameters Used</h6>
+                <pre><code>{{ llm_params_json }}</code></pre>
+                <h6 class="mt-3">Diagnostic Data</h6>
+                <pre id="diagnosticPre"><code>{{ oom_trace_details|safe }}</code></pre>
+            </div>
+        </div>
+
+        <!-- MAT Report Table of Contents -->
+        <div class="card mb-4">
+            <div class="card-header fs-5"><i class="bi bi-list-ul"></i> MAT Report Table of Contents</div>
+            <div class="card-body">
+                <div class="list-group">
+                    {% if mat_report_entry_file %}
+                    <a href="{{ url_for('get_file_from_run', run=run_name, filename=mat_report_entry_file) }}" class="list-group-item list-group-item-action">{{ mat_report_index_link_text }}</a>
+                    {% if 'not found' not in mat_report_toc_link_text|lower %}
+                    <a href="{{ url_for('get_file_from_run', run=run_name, filename=mat_report_entry_file.replace('index.html', 'toc.html')) }}" class="list-group-item list-group-item-action">{{ mat_report_toc_link_text }}</a>
+                    {% endif %}
+                    {% endif %}
+                    {% for entry in mat_toc_entries %}
+                    <a href="{{ entry.url }}" class="list-group-item list-group-item-action">{{ entry.text }}</a>
+                    {% endfor %}
+                    {% for entry in mat_index_files %}
+                    <a href="{{ entry.url }}" class="list-group-item list-group-item-action">{{ entry.text }}</a>
+                    {% endfor %}
+                    {% if not mat_report_entry_file and not mat_toc_entries and not mat_index_files %}
+                    <span class="list-group-item text-muted">No table of contents entries available.</span>
+                    {% endif %}
                 </div>
             </div>
         </div>
@@ -144,30 +202,22 @@
             </div>
         </div>
 
-        <!-- Diagnostic Data -->
+        <!-- Run Details -->
         <div class="card mb-4">
-            <div class="card-header fs-5"><i class="bi bi-file-earmark-text"></i> Diagnostic Data</div>
-            <div class="card-body" style="max-height: 800px; overflow-y: auto;">
-                <div class="input-group input-group-sm mb-2">
-                    <span class="input-group-text">Search</span>
-                    <input id="rawSearchInput" type="text" class="form-control" placeholder="Find in data...">
+            <div class="card-header fs-5"><i class="bi bi-info-circle"></i> Run Details</div>
+            <div class="card-body">
+                <p class="mb-2"><strong>Input File:</strong><br><small class="text-muted">{{ hprof_source }}</small></p>
+                <p class="mb-2"><strong>Timestamp:</strong><br>{{ run_time }}</p>
+                <p class="mb-2"><strong>MAT Memory:</strong> {{ mat_memory_setting }} MB</p>
+                <p class="mb-2"><strong>MAT Report Type:</strong> {{ mat_report_type_used }}</p>
+                <div class="mt-3">
+                    <label for="notesTextarea" class="form-label">Run Notes</label>
+                    <textarea id="notesTextarea" class="form-control mb-2" rows="4" placeholder="Add notes...">{{ user_notes }}</textarea>
+                    <button id="saveNotesBtn" class="btn btn-sm btn-primary">Save Notes</button>
                 </div>
-                <h6>LLM Parameters Used</h6>
-                <pre><code>{{ llm_params_json }}</code></pre>
-                <h6 class="mt-3">Diagnostic Data</h6>
-                <pre id="diagnosticPre"><code>{{ oom_trace_details|safe }}</code></pre>
-                {% if 'not available' not in mat_problem_suspect_html %}
-                <hr>
-                <h6 class="mt-3">MAT Problem Suspect Details</h6>
-                {% if mat_overview_pie_chart_url %}
-                <img src="{{ mat_overview_pie_chart_url }}" class="img-fluid rounded mb-3" alt="MAT Pie Chart">
-                {% endif %}
-                {{ mat_problem_suspect_html|safe }}
-                {% endif %}
             </div>
         </div>
-
-        <!-- Viewable Other Files -->
+<!-- Viewable Other Files -->
         <div class="card mb-4">
             <div class="card-header fs-5"><i class="bi bi-folder2-open"></i> View Other Files</div>
             <div class="card-body">
@@ -278,6 +328,10 @@
     <script>
         const RUN_NAME = "{{ run_name }}";
         const SAVED_PROMPTS = {{ saved_prompts|tojson|safe }};
+        const darkModeToggle = document.getElementById('darkModeToggle');
+        darkModeToggle.addEventListener('click', () => {
+            document.body.classList.toggle('dark-mode');
+        });
 
         // --- Status Update Logic ---
         function setStatus(newStatus) {


### PR DESCRIPTION
## Summary
- Reorder run detail page so MAT problem suspect details appear first followed by diagnostic data and a new MAT report table of contents before the LLM analysis
- Add a dark mode toggle and styling for the run view

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689666c8bbd48325a49a9035ebdd9a88