### PR TITLE
Add missing imports to tests

### DIFF
--- a/tests/test_helper_scripts.py
+++ b/tests/test_helper_scripts.py
@@ -1,4 +1,5 @@
 import importlib.util
+import os
 from pathlib import Path
 
 ROOT_DIR = Path(__file__).resolve().parents[1]

--- a/tests/test_resource_and_remediation.py
+++ b/tests/test_resource_and_remediation.py
@@ -1,5 +1,5 @@
-import json
 from pathlib import Path
+import json
 import importlib.util
 
 import pytest


### PR DESCRIPTION
## Summary
- ensure `os`, `Path`, and `json` are imported correctly in test modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6896876dcb9483258ea884e8f4b19de1