### PR TITLE
feat: allow customizing nmap scan options

### DIFF
--- a/config.json
+++ b/config.json
@@ -76,5 +76,6 @@
         "reduce_llm_context": true,
         "basic_wireshark_tasks": true
     },
-    "lite_mode_enabled": false
+    "lite_mode_enabled": false,
+    "nmap_options": []
 }

--- a/config_handler.py
+++ b/config_handler.py
@@ -92,7 +92,8 @@ Your response:
         "reduce_llm_context": True,
         "basic_wireshark_tasks": True
     },
-    "lite_mode_enabled": False
+    "lite_mode_enabled": False,
+    "nmap_options": []
 }
 
 def load_settings():

--- a/network_scanner.py
+++ b/network_scanner.py
@@ -1,15 +1,21 @@
 import os
 import subprocess
 from pathlib import Path
+from typing import List, Optional
+
+import config_handler
 
 PROJECT_ROOT = Path(__file__).resolve().parent
 RESULTAT_DIR = PROJECT_ROOT / "Resultat"
 
 
-def run_nmap_scan(target: str, run_dir: Path) -> str:
+def run_nmap_scan(target: str, run_dir: Path, extra_options: Optional[List[str]] = None) -> str:
     """Run an nmap scan if nmap is available."""
     output_file = run_dir / f"nmap_{target.replace('/', '_')}.txt"
-    cmd = ["nmap", "-A", target]
+    cmd = ["nmap", "-A"]
+    if extra_options:
+        cmd.extend(extra_options)
+    cmd.append(target)
     try:
         with open(output_file, "w", encoding="utf-8") as f:
             subprocess.run(cmd, stdout=f, stderr=subprocess.STDOUT, check=False)
@@ -22,4 +28,26 @@ def run_nmap_scan(target: str, run_dir: Path) -> str:
 def scan_target(target: str, run_name: str):
     run_dir = RESULTAT_DIR / run_name
     os.makedirs(run_dir, exist_ok=True)
-    return run_nmap_scan(target, run_dir)
+    settings = config_handler.load_settings()
+    extra_opts = settings.get("nmap_options", [])
+    return run_nmap_scan(target, run_dir, extra_opts)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run an Nmap scan and save the output.")
+    parser.add_argument("target", help="Target to scan")
+    parser.add_argument("--run-name", default="run", help="Output directory name")
+    parser.add_argument(
+        "--options",
+        nargs="*",
+        help="Extra options for nmap (overrides config file)",
+    )
+    args = parser.parse_args()
+
+    opts = args.options if args.options is not None else config_handler.load_settings().get("nmap_options", [])
+    run_dir = RESULTAT_DIR / args.run_name
+    os.makedirs(run_dir, exist_ok=True)
+    output_path = run_nmap_scan(args.target, run_dir, opts)
+    print(output_path)

--- a/tests/test_helper_scripts.py
+++ b/tests/test_helper_scripts.py
@@ -1,7 +1,26 @@
 import importlib.util
 from pathlib import Path
+import sys
+import types
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+qtcore = types.ModuleType('PySide6.QtCore')
+
+class QStandardPaths:
+    class StandardLocation:
+        HomeLocation = 0
+
+    @staticmethod
+    def writableLocation(_):
+        return str(ROOT_DIR)
+
+qtcore.QStandardPaths = QStandardPaths
+pyside6 = types.ModuleType('PySide6')
+pyside6.QtCore = qtcore
+sys.modules.setdefault('PySide6', pyside6)
+sys.modules.setdefault('PySide6.QtCore', qtcore)
 
 # Load modules
 spec_ns = importlib.util.spec_from_file_location("network_scanner", ROOT_DIR / "network_scanner.py")
@@ -19,7 +38,7 @@ spec_la.loader.exec_module(log_aggregator)
 
 def test_network_scan_and_cleanup(tmp_path: Path):
     run_dir = tmp_path
-    out_path = network_scanner.run_nmap_scan("127.0.0.1", run_dir)
+    out_path = network_scanner.run_nmap_scan("127.0.0.1", run_dir, ["-Pn"])
     assert Path(out_path).exists()
 
 


### PR DESCRIPTION
## Summary
- add `nmap_options` to default settings and config
- allow `run_nmap_scan` to accept extra options and load them from config
- expose Nmap options via a small CLI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896877045cc8325b673fd16d84b099c