### PR TITLE
Expose run metrics via API and Chart.js dashboard

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -147,7 +147,7 @@ def index():
     return render_template("index.html", runs_with_status=runs_with_status)
 
 
-@app.route("/api/runs") 
+@app.route("/api/runs")
 def get_runs_api():
     ensure_resultat_dir(); runs_with_status = []
     try:
@@ -167,6 +167,25 @@ def get_runs_api():
             runs_with_status.append({"name": run_name, "user_status": status, "tags": tags})
     except Exception as e: log_dashboard_error(f"API Err read Resultat: {e}"); return jsonify({"error": str(e)}), 500
     return jsonify(runs_with_status)
+
+
+@app.route("/api/metrics/<run>")
+def get_metrics_api(run):
+    """Return recent system metrics for a run in JSON form."""
+
+    ensure_resultat_dir()
+    metrics_file = os.path.join(RESULTAT_DIR_DASHBOARD, run, "system_metrics.jsonl")
+    if not os.path.isfile(metrics_file):
+        return jsonify([])
+
+    try:
+        with open(metrics_file, "r", encoding="utf-8") as f:
+            lines = f.readlines()[-100:]
+        entries = [json.loads(line) for line in lines if line.strip()]
+        return jsonify(entries)
+    except Exception as e:
+        log_dashboard_error(f"Metrics: failed to read {metrics_file}: {e}")
+        return jsonify({"error": str(e)}), 500
 
 def _load_run_data_common(run_dir_path, run_name_for_log):
     data = {

--- a/resource_monitor.py
+++ b/resource_monitor.py
@@ -10,6 +10,7 @@ except ImportError:  # pragma: no cover - handled by graceful fallback
 
 PROJECT_ROOT = Path(__file__).resolve().parent
 RESULTAT_DIR = PROJECT_ROOT / "Resultat"
+METRICS_FILE_NAME = "system_metrics.jsonl"
 
 
 def collect_metrics(output_file: str | os.PathLike):
@@ -56,12 +57,33 @@ def collect_metrics(output_file: str | os.PathLike):
     return metrics
 
 
-def collect_once_in_resultat(run_name: str):
-    """Convenience wrapper to collect metrics to a run subdirectory."""
+def run_metrics_path(run_name: str) -> Path:
+    """Return the metrics file path for a given run.
+
+    Parameters
+    ----------
+    run_name:
+        Name of the run directory inside ``Resultat``.
+    """
+
     run_dir = RESULTAT_DIR / run_name
-    os.makedirs(run_dir, exist_ok=True)
-    out_path = run_dir / "system_metrics.jsonl"
-    return collect_metrics(out_path)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    return run_dir / METRICS_FILE_NAME
+
+
+def collect_once_in_resultat(run_name: str):
+    """Collect metrics and append them to a run-specific file.
+
+    This convenience wrapper ensures metrics are written to a file under
+    ``Resultat/<run_name>/`` so that the dashboard can access them.
+    """
+
+    return collect_metrics(run_metrics_path(run_name))
+
+
+def collect_metrics_for_run(run_name: str):
+    """Alias of :func:`collect_once_in_resultat` for clearer naming."""
+    return collect_once_in_resultat(run_name)
 
 
 def collect_metrics_periodically(
@@ -92,4 +114,16 @@ def collect_metrics_periodically(
         if i < iterations - 1:
             time.sleep(max(0.0, interval_seconds))
     return results
+
+
+def collect_metrics_periodically_for_run(
+    run_name: str,
+    iterations: int,
+    interval_seconds: float = 1.0,
+) -> list[dict]:
+    """Collect metrics repeatedly for a run-specific file."""
+
+    return collect_metrics_periodically(
+        run_metrics_path(run_name), iterations, interval_seconds
+    )
 

--- a/templates/view_run.html
+++ b/templates/view_run.html
@@ -6,6 +6,7 @@
     <title>Run: {{ run_name }} - DumpBehandler</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
         <style>
         body {
             font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif;
@@ -217,6 +218,13 @@
                 </div>
             </div>
         </div>
+        <!-- System Metrics -->
+        <div class="card mb-4">
+            <div class="card-header fs-5"><i class="bi bi-activity"></i> System Metrics</div>
+            <div class="card-body">
+                <canvas id="metricsChart" height="100"></canvas>
+            </div>
+        </div>
 <!-- Viewable Other Files -->
         <div class="card mb-4">
             <div class="card-header fs-5"><i class="bi bi-folder2-open"></i> View Other Files</div>
@@ -332,6 +340,36 @@
         darkModeToggle.addEventListener('click', () => {
             document.body.classList.toggle('dark-mode');
         });
+
+        // --- Metrics Chart ---
+        async function loadMetrics() {
+            try {
+                const resp = await fetch(`/api/metrics/${RUN_NAME}`);
+                if (!resp.ok) return;
+                const data = await resp.json();
+                if (!Array.isArray(data) || data.length === 0) return;
+                const labels = data.map(d => new Date(d.timestamp * 1000).toLocaleTimeString());
+                const cpu = data.map(d => d.cpu_percent);
+                const mem = data.map(d => d.memory_percent);
+                const ctx = document.getElementById('metricsChart');
+                new Chart(ctx, {
+                    type: 'line',
+                    data: {
+                        labels,
+                        datasets: [
+                            { label: 'CPU %', data: cpu, borderColor: 'rgb(75, 192, 192)', fill: false },
+                            { label: 'Memory %', data: mem, borderColor: 'rgb(255, 99, 132)', fill: false }
+                        ]
+                    },
+                    options: {
+                        responsive: true,
+                        scales: { y: { beginAtZero: true, max: 100 } }
+                    }
+                });
+            } catch (err) {
+                console.error('Failed to load metrics', err);
+            }
+        }
 
         // --- Status Update Logic ---
         function setStatus(newStatus) {
@@ -524,6 +562,7 @@
 
         // Initialize chat when the page loads
         document.addEventListener('DOMContentLoaded', initializeChat);
+        document.addEventListener('DOMContentLoaded', loadMetrics);
 
         // Wire up chat input
         sendChatBtn.addEventListener('click', handleSendChat);


### PR DESCRIPTION
## Summary
- write system metrics to a run-specific `system_metrics.jsonl` file
- add `/api/metrics/<run>` endpoint returning recent metric entries
- display CPU and memory charts in run view using Chart.js

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68968772104c8325bb3a5f1cae2fea12