### PR TITLE
Add remediation plugin framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,21 @@ Run the automated tests with [pytest](https://docs.pytest.org/):
 pytest
 ```
 
+## Remediation Plugins
+
+`remediation_engine` can be extended with additional tag-to-remediation
+suggestions by placing Python modules inside the `remediation_plugins`
+directory. Each plugin should define a `TAG_TO_REMEDIATION` dictionary that
+maps tag names to suggestion strings. All plugin mappings are merged with the
+built-in defaults at runtime.
+
+```python
+# remediation_plugins/custom.py
+TAG_TO_REMEDIATION = {
+    "CustomTag": "Custom remediation instructions."
+}
+```
+
 ## Security & Operational Guide
 
 The application analyses potentially untrusted artifacts. The following steps

--- a/remediation_engine.py
+++ b/remediation_engine.py
@@ -1,9 +1,11 @@
 from pathlib import Path
+import importlib.util
 import json
 import os
 
 PROJECT_ROOT = Path(__file__).resolve().parent
 RESULTAT_DIR = PROJECT_ROOT / "Resultat"
+PLUGIN_DIR = PROJECT_ROOT / "remediation_plugins"
 
 TAG_TO_REMEDIATION = {
     "OutdatedPackages": "Run system package updates to apply latest security patches.",
@@ -11,6 +13,25 @@ TAG_TO_REMEDIATION = {
     "HighCPU": "Identify processes with high CPU utilization and optimize or restart them.",
     "HighThreadCount": "Check for thread leaks or misconfigured thread pools.",
 }
+
+
+def _load_plugin_mappings():
+    """Load tag-to-remediation mappings from all plugin modules."""
+    if not PLUGIN_DIR.exists():
+        return
+    for plugin_path in PLUGIN_DIR.glob("*.py"):
+        if plugin_path.name == "__init__.py":
+            continue
+        spec = importlib.util.spec_from_file_location(plugin_path.stem, plugin_path)
+        if spec and spec.loader:
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            mapping = getattr(module, "TAG_TO_REMEDIATION", None)
+            if isinstance(mapping, dict):
+                TAG_TO_REMEDIATION.update(mapping)
+
+
+_load_plugin_mappings()
 
 
 def generate_remediation(tags: list[str], output_file: str | os.PathLike):

--- a/remediation_plugins/__init__.py
+++ b/remediation_plugins/__init__.py
@@ -1,0 +1,6 @@
+"""Remediation plugins package.
+
+Each module in this package can define a `TAG_TO_REMEDIATION` dictionary
+mapping LLM-generated tags to remediation suggestion strings. The
+`remediation_engine` automatically loads these mappings at runtime.
+"""


### PR DESCRIPTION
## Summary
- load tag-to-remediation mappings from new `remediation_plugins` directory
- document plugin interface for contributors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68968773b92c8325b1000f0eeff06b86