### PR TITLE
Handle cancellation during live capture sniff loop

### DIFF
--- a/capture_dialog.py
+++ b/capture_dialog.py
@@ -55,18 +55,24 @@ class CaptureWorker(QObject):
                 tshark_path=self.tshark_path,
                 custom_parameters=['-w', self.output_file]
             )
+            elapsed = 0
+            chunk_seconds = 1
+            while elapsed < self.duration:
+                remaining = min(chunk_seconds, self.duration - elapsed)
+                capture.sniff(timeout=remaining)
+                elapsed += remaining
+                self.countdown.emit(self.duration - elapsed)
+                if self.is_cancelled:
+                    capture.close()
+                    if os.path.exists(self.output_file):
+                        try:
+                            os.remove(self.output_file)
+                        except OSError as e:
+                            self.progress.emit(f"Could not delete partial capture file: {e}")
+                    self.error.emit("Capture was cancelled.")
+                    return
 
-            capture.sniff(timeout=self.duration)  # ✅ THE CRITICAL MISSING LINE
             capture.close()
-
-            if self.is_cancelled:
-                if os.path.exists(self.output_file):
-                    try:
-                        os.remove(self.output_file)
-                    except OSError as e:
-                        self.progress.emit(f"Could not delete partial capture file: {e}")
-                self.error.emit("Capture was cancelled.")
-                return
 
             self.countdown.emit(0)
             self.progress.emit("Finalizing capture file...")


### PR DESCRIPTION
## Summary
- Allow live capture sniff to be interrupted by checking `is_cancelled` between one-second chunks
- Close capture and delete partial files when cancelled

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689688ed34b483259cf2e9aa4ffd6885