### PR TITLE
Sanitize run names before creating result directories

### DIFF
--- a/log_aggregator.py
+++ b/log_aggregator.py
@@ -1,7 +1,11 @@
 import os
 from pathlib import Path
+import sys
 
 PROJECT_ROOT = Path(__file__).resolve().parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.append(str(PROJECT_ROOT))
+from utils import sanitize_run_name
 RESULTAT_DIR = PROJECT_ROOT / "Resultat"
 
 
@@ -29,6 +33,7 @@ def gather_system_logs(run_dir: Path) -> str:
 
 
 def gather_for_run(run_name: str):
+    run_name = sanitize_run_name(run_name)
     run_dir = RESULTAT_DIR / run_name
     os.makedirs(run_dir, exist_ok=True)
     return gather_system_logs(run_dir)

--- a/network_scanner.py
+++ b/network_scanner.py
@@ -1,8 +1,12 @@
 import os
 import subprocess
 from pathlib import Path
+import sys
 
 PROJECT_ROOT = Path(__file__).resolve().parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.append(str(PROJECT_ROOT))
+from utils import sanitize_run_name
 RESULTAT_DIR = PROJECT_ROOT / "Resultat"
 
 
@@ -20,6 +24,7 @@ def run_nmap_scan(target: str, run_dir: Path) -> str:
 
 
 def scan_target(target: str, run_name: str):
+    run_name = sanitize_run_name(run_name)
     run_dir = RESULTAT_DIR / run_name
     os.makedirs(run_dir, exist_ok=True)
     return run_nmap_scan(target, run_dir)

--- a/security_scanner.py
+++ b/security_scanner.py
@@ -1,8 +1,12 @@
 import os
 import subprocess
 from pathlib import Path
+import sys
 
 PROJECT_ROOT = Path(__file__).resolve().parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.append(str(PROJECT_ROOT))
+from utils import sanitize_run_name
 RESULTAT_DIR = PROJECT_ROOT / "Resultat"
 
 
@@ -56,7 +60,12 @@ def run_yara_scan(rule_file: str | os.PathLike, target: str | os.PathLike, run_d
     return str(output_file)
 
 
-def run_all_scans(run_name: str, yara_rule: str | os.PathLike | None = None, yara_target: str | os.PathLike | None = None):
+def run_all_scans(
+    run_name: str,
+    yara_rule: str | os.PathLike | None = None,
+    yara_target: str | os.PathLike | None = None,
+):
+    run_name = sanitize_run_name(run_name)
     run_dir = RESULTAT_DIR / run_name
     os.makedirs(run_dir, exist_ok=True)
     results = {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+import importlib.util
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+spec_utils = importlib.util.spec_from_file_location("utils", ROOT_DIR / "utils.py")
+utils = importlib.util.module_from_spec(spec_utils)
+spec_utils.loader.exec_module(utils)
+
+
+def test_sanitize_run_name_normalizes_separators_and_chars():
+    assert utils.sanitize_run_name("foo/bar?baz") == "foo_bar_baz"
+
+
+def test_sanitize_run_name_rejects_traversal():
+    with pytest.raises(ValueError):
+        utils.sanitize_run_name("../evil")

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,43 @@
+import os
+import re
+
+
+def sanitize_run_name(run_name: str) -> str:
+    """Sanitize a run name for safe filesystem usage.
+
+    Replaces path separators and disallows path traversal or dangerous
+    characters. Only alphanumeric characters, dashes, underscores and
+    dots are preserved; everything else is converted to underscores.
+
+    Parameters
+    ----------
+    run_name: str
+        Proposed name of a run.
+
+    Returns
+    -------
+    str
+        Sanitized run name safe for directory creation.
+
+    Raises
+    ------
+    ValueError
+        If the provided name resolves to an empty string or contains
+        path traversal components.
+    """
+    if run_name is None:
+        raise ValueError("run_name cannot be None")
+
+    # Replace path separators with underscores.
+    sanitized = run_name.replace(os.sep, "_")
+    if os.altsep:
+        sanitized = sanitized.replace(os.altsep, "_")
+
+    # Replace any character not explicitly allowed.
+    sanitized = re.sub(r"[^A-Za-z0-9._-]", "_", sanitized)
+
+    # Reject names that could traverse directories or are empty.
+    if sanitized in ("", ".", "..") or ".." in sanitized:
+        raise ValueError(f"Invalid run name: {run_name!r}")
+
+    return sanitized


### PR DESCRIPTION
## Summary
- add `sanitize_run_name` utility to normalize and validate run names
- use sanitizer in network scanner, log aggregator, and security scanner before creating run directories
- cover sanitizer behavior with unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896890e6be083258490ae921bcf6d0b