### PR TITLE
Add uninstallation support in tool manager

### DIFF
--- a/tests/test_tool_manager.py
+++ b/tests/test_tool_manager.py
@@ -1,0 +1,69 @@
+import os
+import sys
+from pathlib import Path
+from PySide6.QtWidgets import QApplication, QMessageBox
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+import tool_manager
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def qapp():
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    yield app
+
+
+def _setup_dummy(dialog, tmp_path, monkeypatch):
+    tool = {"id": "dummy", "name": "Dummy", "install_path": "dummy_install"}
+    install_dir = tmp_path / "dummy_install"
+    install_dir.mkdir()
+    (install_dir / "file.txt").write_text("data")
+
+    original_find = dialog._find_installed_tool_dir
+
+    def fake_find(t):
+        if t.get("id") == "dummy":
+            return install_dir
+        return original_find(t)
+
+    monkeypatch.setattr(dialog, "_find_installed_tool_dir", fake_find)
+    monkeypatch.setattr(QMessageBox, "question", lambda *a, **k: QMessageBox.StandardButton.Yes)
+    monkeypatch.setattr(QMessageBox, "information", lambda *a, **k: QMessageBox.StandardButton.Ok)
+    monkeypatch.setattr(QMessageBox, "warning", lambda *a, **k: QMessageBox.StandardButton.Ok)
+    return tool, install_dir
+
+
+def test_uninstall_tool_removes_directory(tmp_path, monkeypatch):
+    dialog = tool_manager.ToolManagerDialog()
+    tool, install_dir = _setup_dummy(dialog, tmp_path, monkeypatch)
+
+    dialog.uninstall_tool(tool, 0)
+
+    assert not install_dir.exists()
+
+
+def test_uninstall_tool_permission_error(tmp_path, monkeypatch):
+    dialog = tool_manager.ToolManagerDialog()
+    tool, install_dir = _setup_dummy(dialog, tmp_path, monkeypatch)
+
+    def fake_rmtree(path):
+        raise PermissionError("denied")
+
+    monkeypatch.setattr(tool_manager.shutil, "rmtree", fake_rmtree)
+    warnings = {}
+
+    def record_warning(*a, **k):
+        warnings["warned"] = True
+        return QMessageBox.StandardButton.Ok
+
+    monkeypatch.setattr(QMessageBox, "warning", record_warning)
+
+    dialog.uninstall_tool(tool, 0)
+
+    assert install_dir.exists()
+    assert warnings.get("warned")

--- a/tool_manager.py
+++ b/tool_manager.py
@@ -3,6 +3,7 @@ import os
 import sys
 import json
 import zipfile
+import shutil
 from pathlib import Path
 import requests
 
@@ -74,11 +75,19 @@ class ToolManagerDialog(QDialog):
         self.setMinimumSize(600, 400)
         self.layout = QVBoxLayout(self)
         self.table = QTableWidget()
-        self.table.setColumnCount(5)
-        self.table.setHorizontalHeaderLabels(["Tool", "Version", "Platform", "Status", "Action"])
+        self.table.setColumnCount(6)
+        self.table.setHorizontalHeaderLabels([
+            "Tool",
+            "Version",
+            "Platform",
+            "Status",
+            "Action",
+            "Uninstall",
+        ])
         self.table.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
         self.table.horizontalHeader().setSectionResizeMode(3, QHeaderView.ResizeMode.ResizeToContents)
         self.table.horizontalHeader().setSectionResizeMode(4, QHeaderView.ResizeMode.ResizeToContents)
+        self.table.horizontalHeader().setSectionResizeMode(5, QHeaderView.ResizeMode.ResizeToContents)
         self.layout.addWidget(self.table)
         self.download_thread, self.download_worker = None, None
         self.load_tools()
@@ -132,19 +141,24 @@ class ToolManagerDialog(QDialog):
             install_dir = self._find_installed_tool_dir(tool)
             status_item = QTableWidgetItem()
             action_button = QPushButton()
+            uninstall_button = QPushButton("Uninstall")
 
             if install_dir is not None:
                 status_item.setText("Installed")
                 status_item.setForeground(Qt.GlobalColor.darkGreen)
                 action_button.setText("Re-install")
+                uninstall_button.setEnabled(True)
             else:
                 status_item.setText("Not Installed")
                 status_item.setForeground(Qt.GlobalColor.red)
                 action_button.setText("Download & Install")
+                uninstall_button.setEnabled(False)
 
             self.table.setItem(row_index, 3, status_item)
             action_button.clicked.connect(lambda checked, t=tool, r=row_index: self.start_download(t, r))
+            uninstall_button.clicked.connect(lambda checked, t=tool, r=row_index: self.uninstall_tool(t, r))
             self.table.setCellWidget(row_index, 4, action_button)
+            self.table.setCellWidget(row_index, 5, uninstall_button)
 
     def start_download(self, tool_info, row_index):
         """
@@ -168,6 +182,44 @@ class ToolManagerDialog(QDialog):
         
         self.download_thread.started.connect(self.download_worker.run)
         self.download_thread.start()
+
+    def uninstall_tool(self, tool_info, row_index):
+        """Deletes the tool's installation directory after user confirmation."""
+        install_path = self._find_installed_tool_dir(tool_info)
+        if not install_path or not install_path.exists():
+            QMessageBox.information(self, "Uninstall", f"{tool_info.get('name')} is not installed.")
+            return
+
+        reply = QMessageBox.question(
+            self,
+            "Confirm Uninstall",
+            f"Are you sure you want to uninstall {tool_info.get('name')}?",
+        )
+        if reply != QMessageBox.StandardButton.Yes:
+            return
+
+        try:
+            shutil.rmtree(install_path)
+        except PermissionError:
+            QMessageBox.warning(
+                self,
+                "Permission Error",
+                f"Permission denied while uninstalling {tool_info.get('name')}.",
+            )
+        except Exception as e:
+            QMessageBox.warning(
+                self,
+                "Uninstall Error",
+                f"Failed to uninstall {tool_info.get('name')}: {e}",
+            )
+        else:
+            QMessageBox.information(
+                self,
+                "Uninstall",
+                f"{tool_info.get('name')} has been uninstalled.",
+            )
+        finally:
+            self.load_tools()
 
     def on_download_error(self, error_msg):
         QMessageBox.critical(self, "Download Error", error_msg)


### PR DESCRIPTION
## Summary
- add Uninstall button for each tool to remove installed directories
- refresh tool table after uninstall and handle permission errors
- cover uninstall logic with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896892714e88325bc0b8dba2066a128