### PR TITLE
Add timeouts and diagnostics to security scans

### DIFF
--- a/network_scanner.py
+++ b/network_scanner.py
@@ -6,13 +6,20 @@ PROJECT_ROOT = Path(__file__).resolve().parent
 RESULTAT_DIR = PROJECT_ROOT / "Resultat"
 
 
-def run_nmap_scan(target: str, run_dir: Path) -> str:
+def run_nmap_scan(target: str, run_dir: Path, timeout: int = 60) -> str:
     """Run an nmap scan if nmap is available."""
     output_file = run_dir / f"nmap_{target.replace('/', '_')}.txt"
     cmd = ["nmap", "-A", target]
     try:
         with open(output_file, "w", encoding="utf-8") as f:
-            subprocess.run(cmd, stdout=f, stderr=subprocess.STDOUT, check=False)
+            try:
+                result = subprocess.run(
+                    cmd, stdout=f, stderr=subprocess.STDOUT, check=False, timeout=timeout
+                )
+                if result.returncode != 0:
+                    f.write(f"\nCommand exited with return code {result.returncode}\n")
+            except subprocess.TimeoutExpired:
+                f.write("nmap scan timed out\n")
     except FileNotFoundError:
         with open(output_file, "w", encoding="utf-8") as f:
             f.write("nmap not installed or not found in PATH\n")

--- a/security_scanner.py
+++ b/security_scanner.py
@@ -6,33 +6,47 @@ PROJECT_ROOT = Path(__file__).resolve().parent
 RESULTAT_DIR = PROJECT_ROOT / "Resultat"
 
 
-def run_lynis_scan(run_dir: Path) -> str:
+def run_lynis_scan(run_dir: Path, timeout: int = 60) -> str:
     """Run a lynis security audit if available."""
     output_file = run_dir / "lynis_report.txt"
     cmd = ["lynis", "audit", "system", "--quiet", "--quick"]
     try:
         with open(output_file, "w", encoding="utf-8") as f:
-            subprocess.run(cmd, stdout=f, stderr=subprocess.STDOUT, check=False)
+            try:
+                result = subprocess.run(
+                    cmd, stdout=f, stderr=subprocess.STDOUT, check=False, timeout=timeout
+                )
+                if result.returncode != 0:
+                    f.write(f"\nCommand exited with return code {result.returncode}\n")
+            except subprocess.TimeoutExpired:
+                f.write("lynis scan timed out\n")
     except FileNotFoundError:
         with open(output_file, "w", encoding="utf-8") as f:
             f.write("lynis not installed or not found in PATH\n")
     return str(output_file)
 
 
-def run_osquery_scan(run_dir: Path) -> str:
+def run_osquery_scan(run_dir: Path, timeout: int = 60) -> str:
     """Run a basic osquery info query if available."""
     output_file = run_dir / "osquery_info.txt"
     cmd = ["osqueryi", "--json", "SELECT version, build_platform FROM osquery_info;"]
     try:
         with open(output_file, "w", encoding="utf-8") as f:
-            subprocess.run(cmd, stdout=f, stderr=subprocess.STDOUT, check=False)
+            try:
+                result = subprocess.run(
+                    cmd, stdout=f, stderr=subprocess.STDOUT, check=False, timeout=timeout
+                )
+                if result.returncode != 0:
+                    f.write(f"\nCommand exited with return code {result.returncode}\n")
+            except subprocess.TimeoutExpired:
+                f.write("osquery scan timed out\n")
     except FileNotFoundError:
         with open(output_file, "w", encoding="utf-8") as f:
             f.write("osqueryi not installed or not found in PATH\n")
     return str(output_file)
 
 
-def run_yara_scan(rule_file: str | os.PathLike, target: str | os.PathLike, run_dir: Path) -> str:
+def run_yara_scan(rule_file: str | os.PathLike, target: str | os.PathLike, run_dir: Path, timeout: int = 60) -> str:
     """Scan a file or directory with yara rules if available.
 
     Parameters
@@ -49,7 +63,14 @@ def run_yara_scan(rule_file: str | os.PathLike, target: str | os.PathLike, run_d
     cmd = ["yara", str(rule_file), str(target)]
     try:
         with open(output_file, "w", encoding="utf-8") as f:
-            subprocess.run(cmd, stdout=f, stderr=subprocess.STDOUT, check=False)
+            try:
+                result = subprocess.run(
+                    cmd, stdout=f, stderr=subprocess.STDOUT, check=False, timeout=timeout
+                )
+                if result.returncode != 0:
+                    f.write(f"\nCommand exited with return code {result.returncode}\n")
+            except subprocess.TimeoutExpired:
+                f.write("yara scan timed out\n")
     except FileNotFoundError:
         with open(output_file, "w", encoding="utf-8") as f:
             f.write("yara not installed or not found in PATH\n")


### PR DESCRIPTION
## Summary
- add timeout handling to `run_nmap_scan` and security scan helpers
- log non-zero exit codes and timeouts to scan output files

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689688f354b083259200877a497d332a