### PR TITLE
Validate YARA paths before scan

### DIFF
--- a/security_scanner.py
+++ b/security_scanner.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 from pathlib import Path
+import logging
 
 PROJECT_ROOT = Path(__file__).resolve().parent
 RESULTAT_DIR = PROJECT_ROOT / "Resultat"
@@ -56,13 +57,30 @@ def run_yara_scan(rule_file: str | os.PathLike, target: str | os.PathLike, run_d
     return str(output_file)
 
 
-def run_all_scans(run_name: str, yara_rule: str | os.PathLike | None = None, yara_target: str | os.PathLike | None = None):
+logger = logging.getLogger(__name__)
+
+
+def run_all_scans(
+    run_name: str,
+    yara_rule: str | os.PathLike | None = None,
+    yara_target: str | os.PathLike | None = None,
+):
     run_dir = RESULTAT_DIR / run_name
     os.makedirs(run_dir, exist_ok=True)
     results = {
         "lynis": run_lynis_scan(run_dir),
         "osquery": run_osquery_scan(run_dir),
+        "yara": None,
     }
     if yara_rule and yara_target:
-        results["yara"] = run_yara_scan(yara_rule, yara_target, run_dir)
+        rule_path = Path(yara_rule)
+        target_path = Path(yara_target)
+        if rule_path.is_file() and target_path.exists():
+            results["yara"] = run_yara_scan(rule_path, target_path, run_dir)
+        else:
+            logger.error(
+                "Invalid YARA configuration: rule '%s' or target '%s' not found",
+                yara_rule,
+                yara_target,
+            )
     return results


### PR DESCRIPTION
## Summary
- verify YARA rule and target paths before executing scan
- log an error and skip YARA scan when paths are invalid
- always include YARA result entry to indicate skipped scans

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896891c24e8832597c74d3497dd8940