### PR TITLE
Add API token authentication to dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ python main.py dashboard
 Then browse to [http://localhost:5000/](http://localhost:5000/) to view the web dashboard.
 To protect the dashboard with a login prompt, set the environment variables `DASHBOARD_USERNAME` and `DASHBOARD_PASSWORD` before starting the app. A `DASHBOARD_SECRET_KEY` can also be supplied to override the default session secret.
 
+For API-only access you can secure the dashboard with a bearer token. Generate a random value using `secrets` and provide it via the `DASHBOARD_API_TOKEN` environment variable or the `--token` command-line argument:
+
+```bash
+export DASHBOARD_API_TOKEN="$(python -c 'import secrets; print(secrets.token_urlsafe(32))')"
+python main.py dashboard
+```
+
+Clients must send the token in an `Authorization` header:
+
+```bash
+curl -H "Authorization: Bearer $DASHBOARD_API_TOKEN" http://localhost:5000/api/runs
+```
+
 The application stores output under the `Resultat` directory.
 
 ### Guard Mode

--- a/config.json
+++ b/config.json
@@ -76,5 +76,6 @@
         "reduce_llm_context": true,
         "basic_wireshark_tasks": true
     },
-    "lite_mode_enabled": false
+    "lite_mode_enabled": false,
+    "dashboard_api_token": ""
 }

--- a/config_handler.py
+++ b/config_handler.py
@@ -92,7 +92,8 @@ Your response:
         "reduce_llm_context": True,
         "basic_wireshark_tasks": True
     },
-    "lite_mode_enabled": False
+    "lite_mode_enabled": False,
+    "dashboard_api_token": ""
 }
 
 def load_settings():

--- a/dashboard.py
+++ b/dashboard.py
@@ -31,11 +31,23 @@ OLLAMA_MODEL_DISPLAY_FALLBACK = "Unknown Model"
 USER_STATUS_PENDING = "pending"
 USER_STATUS_RESOLVED = "resolved"
 
-DASHBOARD_PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__)) 
+DASHBOARD_PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 CONFIG_FILE_PATH_DASHBOARD = os.path.join(DASHBOARD_PROJECT_ROOT, "config.json")
-RESULTAT_DIR_DASHBOARD = os.path.join(os.getcwd(), "Resultat") 
+RESULTAT_DIR_DASHBOARD = os.path.join(os.getcwd(), "Resultat")
 DASHBOARD_LOG_FILE = os.path.join(os.getcwd(), "dashboard_log.txt")
-app.config["TOKEN_AUTH"] = False
+
+# Optional bearer token used for API requests when TOKEN_AUTH is enabled
+API_TOKEN = os.getenv("DASHBOARD_API_TOKEN")
+if not API_TOKEN:
+    try:
+        with open(CONFIG_FILE_PATH_DASHBOARD, "r", encoding="utf-8") as f:
+            cfg = json.load(f)
+            API_TOKEN = cfg.get("dashboard_api_token")
+    except Exception:
+        API_TOKEN = None
+
+app.config["TOKEN_AUTH"] = bool(API_TOKEN)
+app.config["API_TOKEN"] = API_TOKEN
 app.config["READ_ONLY_MODE"] = False
 
 
@@ -53,6 +65,19 @@ def require_login():
 def enforce_read_only():
     if app.config.get("READ_ONLY_MODE") and request.method not in {"GET", "HEAD"}:
         abort(405)
+
+
+@app.before_request
+def validate_token_auth():
+    """Validate Authorization header when token-based auth is enabled."""
+    if not app.config.get("TOKEN_AUTH"):
+        return
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        return Response("Missing token", 401)
+    token = auth_header.split(" ", 1)[1].strip()
+    if token != app.config.get("API_TOKEN"):
+        return Response("Invalid token", 403)
 
 
 @app.route("/login", methods=["GET", "POST"])
@@ -858,14 +883,17 @@ def main(argv=None, *, port=5000, host="127.0.0.1", token=None):
             i += 1
 
     if token:
-        app.config["TOKEN_AUTH"] = token
+        app.config["API_TOKEN"] = token
+        app.config["TOKEN_AUTH"] = True
+
+    if app.config.get("TOKEN_AUTH"):
         def missing_model_html(start_response):
             start_response("404 Not Found", [('Content-Type', 'text/html')])
             return [b"<h1>Model not found</h1>"]
         dispatch_app = DispatcherMiddleware(missing_model_html, {
             "/": app
         })
-        print(f"WebDashboard (auth) → http://{host}:{port}", flush=True)
+        print(f"WebDashboard (token auth) → http://{host}:{port}", flush=True)
         try:
             run_simple(host, port, dispatch_app, use_reloader=False)
         except OSError as e: print(f"Flask start fail: {e}"); return 1


### PR DESCRIPTION
## Summary
- add `DASHBOARD_API_TOKEN` configuration option and env var fallback
- validate `Authorization` headers when token auth is enabled
- document generation and use of dashboard API tokens

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896892e4a288325b3a9eea3424eaa7e