### PR TITLE
Use chunked log reads

### DIFF
--- a/log_aggregator.py
+++ b/log_aggregator.py
@@ -21,7 +21,8 @@ def gather_system_logs(run_dir: Path) -> str:
             try:
                 with open(p, "r", encoding="utf-8", errors="ignore") as src:
                     out_f.write(f"--- {p} ---\n")
-                    out_f.write(src.read())
+                    for chunk in iter(lambda: src.read(65536), ""):
+                        out_f.write(chunk)
                     out_f.write("\n")
             except Exception as e:
                 out_f.write(f"Could not read {p}: {e}\n")


### PR DESCRIPTION
## Summary
- Replace `src.read()` with chunked reads in log aggregation for large log files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896896c6c8c8325acd421526e7dd492