### PR TITLE
Fix config handler JSON syntax error

### DIFF
--- a/config_handler.py
+++ b/config_handler.py
@@ -95,7 +95,7 @@ Your response:
     },
     "lite_mode_enabled": False,
 
-    "dashboard_api_token": ""
+    "dashboard_api_token": "",
 
     "nmap_options": []
 


### PR DESCRIPTION
## Summary
- Fix missing comma in `config_handler.py`'s default settings

## Testing
- `pytest tests/test_config_handler.py -q`
- `pytest tests/test_tool_manager.py -vv`
- `pytest tests/test_package.py tests/test_helper_scripts.py tests/test_resource_and_remediation.py tests/test_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6896932f922083258e0c3bfb1e992b75