### PR TITLE
Add TCP error analysis for Wireshark runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - Optional Guard Mode for automatically watching a folder
 - Live capture of network traffic using tshark
 - Configurable keyword search within packet captures
+- Optional TCP error summaries (retransmissions, lost segments, resets)
 - Manage optional tools via the built in tool manager
 - Binary analysis with Ghidra, using a bundled download or a user-selected system installation
 - Configurable prompt templates for LLM based analysis

--- a/config.json
+++ b/config.json
@@ -68,6 +68,7 @@
         "dns_stats": true,
         "http_reqs": true,
         "tls_alerts": true,
+        "tcp_errors": true,
         "slow_resps": true
     },
     "wireshark_keyword_filters": [],

--- a/config_handler.py
+++ b/config_handler.py
@@ -86,7 +86,8 @@ Your response:
     "llm_params_group_checked": False,
     "wireshark_tasks": {
         "tcp_conv": True, "ip_conv": False, "dns_stats": True,
-        "http_reqs": True, "tls_alerts": True, "slow_resps": False
+        "http_reqs": True, "tls_alerts": True, "tcp_errors": True,
+        "slow_resps": False
     },
     "wireshark_keyword_filters": [],
     "lite_mode": {

--- a/main_window.py
+++ b/main_window.py
@@ -523,6 +523,7 @@ class MainWindow(QWidget):
             {"id": "dns_stats", "name": "DNS Statistics", "desc": "Analyze DNS queries and responses for errors."},
             {"id": "http_reqs", "name": "HTTP Requests", "desc": "Extract all HTTP/1.x requests (host, method, URI)."},
             {"id": "tls_alerts", "name": "TLS/SSL Alerts", "desc": "Scan for secure connection failures and warnings."},
+            {"id": "tcp_errors", "name": "TCP Errors", "desc": "List retransmissions, lost segments and resets."},
             {"id": "slow_resps", "name": "Slow TCP Responses", "desc": "Find TCP packets with a response time > 200ms."}
         ]
 

--- a/monitor.py
+++ b/monitor.py
@@ -148,6 +148,7 @@ def run_tshark_task(pcap_path, tshark_exe_path, task_id):
         "dns_stats":  {"cmd": ["-q", "-z", "dns,tree"], "title": "DNS Statistics"},
         "http_reqs":  {"cmd": ["-Y", "http.request", "-T", "fields", "-e", "http.host", "-e", "http.request.method", "-e", "http.request.uri"], "title": "HTTP Requests"},
         "tls_alerts": {"cmd": ["-Y", "tls.alert_message", "-T", "fields", "-e", "frame.number", "-e", "ip.src", "-e", "ip.dst", "-e", "tls.alert_message.desc"], "title": "TLS/SSL Alerts"},
+        "tcp_errors": {"cmd": ["-Y", "tcp.analysis.retransmission || tcp.analysis.fast_retransmission || tcp.analysis.lost_segment || tcp.flags.reset==1", "-T", "fields", "-e", "frame.number", "-e", "ip.src", "-e", "ip.dst", "-e", "_ws.col.Info"], "title": "TCP Errors"},
         "slow_resps": {"cmd": ["-Y", "tcp.time_delta > 0.2", "-T", "fields", "-e", "frame.number", "-e", "ip.src", "-e", "ip.dst", "-e", "tcp.time_delta"], "title": "Slow TCP Responses (>200ms)"}
     }
 


### PR DESCRIPTION
## Summary
- Collect TCP retransmissions, lost segments, and resets during tshark runs
- Surface TCP error task in GUI and default config
- Document optional TCP error summaries in README

## Testing
- `pytest tests/test_package.py tests/test_tool_manager.py tests/test_helper_scripts.py tests/test_resource_and_remediation.py tests/test_utils.py`
- `pytest tests/test_config_handler.py`


------
https://chatgpt.com/codex/tasks/task_e_6896a2db7ddc83259f53468393141e12